### PR TITLE
Prevent scheduling polling attempts that would exceed timeout

### DIFF
--- a/Sources/AsyncPoller/AsyncPoller.swift
+++ b/Sources/AsyncPoller/AsyncPoller.swift
@@ -68,7 +68,9 @@ public actor AsyncPoller<T: Sendable> {
                 return result
             }
 
-            if let startTime = startTime, Date.now.timeIntervalSince(startTime) > configuration.timeoutInterval {
+            let nextInterval = configuration.pollingInterval(iteration: iteration)
+
+            if let startTime = startTime, Date.now.timeIntervalSince(startTime) + nextInterval > configuration.timeoutInterval {
                 throw PollingError.timeout
             }
 

--- a/Sources/AsyncPoller/AsyncPoller.swift
+++ b/Sources/AsyncPoller/AsyncPoller.swift
@@ -74,7 +74,7 @@ public actor AsyncPoller<T: Sendable> {
                 throw PollingError.timeout
             }
 
-            try await Task.sleep(nanoseconds: UInt64(configuration.pollingInterval(iteration: iteration) * 1_000_000_000))
+            try await Task.sleep(nanoseconds: UInt64(nextInterval * 1_000_000_000))
         }
         throw CancellationError()
     }

--- a/Tests/AsyncPollerTests/AsyncPollerTests.swift
+++ b/Tests/AsyncPollerTests/AsyncPollerTests.swift
@@ -27,8 +27,8 @@ struct AsyncPollerTests {
     @Test("Polling timeout")
     func timeout() async throws {
         let configuration = SimplePollingConfiguration(
-            pollingInterval: 0.000001,
-            timeoutInterval: 0.0001
+            pollingInterval: 1.5,
+            timeoutInterval: 2
         )
         let condition: (String) -> Bool = { $0 == "success" }
         let pollingJob: @Sendable () async -> String = {
@@ -40,6 +40,8 @@ struct AsyncPollerTests {
         await #expect(throws: PollingError.timeout) {
             let _ = try await poller.start()
         }
+
+        await #expect(poller.iteration == 2)
     }
 
     @Test("Already Polling")

--- a/Tests/AsyncPollerTests/AsyncPollerTests.swift
+++ b/Tests/AsyncPollerTests/AsyncPollerTests.swift
@@ -27,8 +27,8 @@ struct AsyncPollerTests {
     @Test("Polling timeout")
     func timeout() async throws {
         let configuration = SimplePollingConfiguration(
-            pollingInterval: 1.5,
-            timeoutInterval: 2
+            pollingInterval: 0.000001,
+            timeoutInterval: 0.0001
         )
         let condition: (String) -> Bool = { $0 == "success" }
         let pollingJob: @Sendable () async -> String = {
@@ -40,8 +40,6 @@ struct AsyncPollerTests {
         await #expect(throws: PollingError.timeout) {
             let _ = try await poller.start()
         }
-
-        await #expect(poller.iteration == 2)
     }
 
     @Test("Already Polling")


### PR DESCRIPTION
Hi @SergeyPetrachkov,

thanks for this async implementation of polling! 

While integrating it, I noticed that the timeout logic allows one additional iteration to start even if it would cause the polling to exceed the timeout.

So, this pull request ensures that the timeout is strictly respected by considering the polling interval when deciding whether to schedule the next attempt.

Let me know what you think! 🙂